### PR TITLE
feat: add service worker to enable message passing between content script and DevTools panel

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,7 +15,13 @@
       ],
       "js": [
         "inspect.js"
+      ],
+      "css": [
+        "inspect.css"
       ]
     }
-  ]
+  ],
+  "background": {
+    "service_worker": "service-worker.js"
+  }
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build && cp manifest.json public/reviz.png dist",
+    "build": "tsc && vite build && cp manifest.json public/reviz.png scripts/inspect.css dist",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/extension/scripts/inspect.css
+++ b/extension/scripts/inspect.css
@@ -1,0 +1,7 @@
+:root {
+  --inspect-color: #419af7;
+}
+
+.mouse-visited {
+  outline: 2px dotted var(--inspect-color);
+}

--- a/extension/scripts/inspect.ts
+++ b/extension/scripts/inspect.ts
@@ -1,63 +1,47 @@
 import { analyzeVisualization } from '@plait-lab/reviz';
 
-/**
- * Reverse engineer a reviz spec and partial program from a selected SVG element.
- *
- * @param el – The SVG element to inspect.
- * @returns – The reviz spec and partial program inferred from the SVG element,
- * or undefined if the element is not an SVG element.
- */
-function inspectSelectedElement(
-  el: Element
-): ReturnType<typeof analyzeVisualization> | undefined {
-  if (isSVGElement(el)) {
-    return analyzeVisualization(el);
-  }
-}
-
-/**
- * A type guard to assert that an element is an SVG element.
- *
- * @param el – The element to check.
- * @returns – True if the element is an SVG element, otherwise false. In addition,
- * TypeScript will narrow the type of the element to SVGSVGElement.
- */
-function isSVGElement(el: Element): el is SVGSVGElement {
-  return el.nodeName === 'svg';
-}
-
 // The class name to apply to an element when hovered.
 const MOUSE_VISITED_CLASSNAME = 'mouse-visited';
 
-function onMouseEnter(event: MouseEvent) {
-  // We only add the mouseenter event listener to SVG elements, making this cast
-  // safe.
+/**
+ * Adds a class to an SVG element on mouseenter to visually indicate selection.
+ * The element cast is safe because we only register this event listener on SVG
+ * elements.
+ *
+ * @param event – The mouseenter event.
+ */
+function onMouseEnter(event: MouseEvent): void {
   const el = event.target as SVGSVGElement;
-
-  // Add a visited class name to the element so we can style it.
   el.classList.add(MOUSE_VISITED_CLASSNAME);
 }
 
+/**
+ * Removes a class from an SVG element on mouseleave to visually indicate
+ * deselection. The element cast is safe because we only register this event
+ * listener on SVG elements.
+ *
+ * @param event – The mouseleave event.
+ */
 function onMouseLeave(event: MouseEvent) {
-  // We only add the mouseleave event listener to SVG elements, making this cast
-  // safe.
   const el = event.target as SVGSVGElement;
-
-  // Remove the visited class name from the element so we can style it.
   el.classList.remove(MOUSE_VISITED_CLASSNAME);
 }
 
+/**
+ * Analyzes a visualization on click and sends the result to the extension
+ * service worker. The element cast is safe because we only register this event
+ * listener on SVG elements.
+ *
+ * @param event – The click event.
+ */
 function onClick(event: MouseEvent) {
   const el = event.target as SVGSVGElement;
-
-  // Analyze the visualzation and send the result to the service worker, which
-  // will forward it to the DevTools page.
   chrome.runtime.sendMessage(analyzeVisualization(el));
 }
 
 /**
- * Activate the inspector by adding a mousemove event listener to the inspected
- * document.
+ * Activates the inspector by registering event listeners on all SVG elements in
+ * the inspected document.
  */
 function activateInspector() {
   document.querySelectorAll('svg').forEach((el) => {
@@ -68,8 +52,8 @@ function activateInspector() {
 }
 
 /**
- * Deactivate the inspector by removing the mousemove event listener from the
- * inspected document.
+ * Deactivates the inspector by removing event listeners on all SVG elements in
+ * the inspected document.
  */
 function deactivateInspector() {
   document.querySelectorAll('svg').forEach((el) => {
@@ -79,26 +63,17 @@ function deactivateInspector() {
   });
 }
 
-// Attach event listeners to all SVG elements in the inspected document.
-
-// This is a bit goofy — allow me to explain. vite + esbuild optimize away this
-// entire module because (1) it's not imported anywhere and (2) even as an
-// entry point, it doesn't import anything else. It's a disconnected node in the
-// module dependency graph. Attaching the function to window ensures it's still
-// bundled; then, it's included in the extension as a content script.
+/**
+ * This is a bit goofy — allow me to explain. vite + esbuild optimize away this
+ * entire module because (1) it's not imported anywhere and (2) even as an entry
+ * point, it doesn't import anything else. It's a disconnected node in the
+ * module dependency graph. Attaching functions we intend to make global to
+ * window ensures it's still compiled; then, it's included in the extension as a
+ * content script.
+ */
 (
   window as Window &
     typeof globalThis & {
-      inspectSelectedElement: typeof inspectSelectedElement;
-      activateInspector: typeof activateInspector;
-      deactivateInspector: typeof deactivateInspector;
-    }
-).inspectSelectedElement = inspectSelectedElement;
-
-(
-  window as Window &
-    typeof globalThis & {
-      inspectSelectedElement: typeof inspectSelectedElement;
       activateInspector: typeof activateInspector;
       deactivateInspector: typeof deactivateInspector;
     }
@@ -107,7 +82,6 @@ function deactivateInspector() {
 (
   window as Window &
     typeof globalThis & {
-      inspectSelectedElement: typeof inspectSelectedElement;
       activateInspector: typeof activateInspector;
       deactivateInspector: typeof deactivateInspector;
     }

--- a/extension/scripts/inspect.ts
+++ b/extension/scripts/inspect.ts
@@ -1,5 +1,12 @@
 import { analyzeVisualization } from '@plait-lab/reviz';
 
+/**
+ * Reverse engineer a reviz spec and partial program from a selected SVG element.
+ *
+ * @param el – The SVG element to inspect.
+ * @returns – The reviz spec and partial program inferred from the SVG element,
+ * or undefined if the element is not an SVG element.
+ */
 function inspectSelectedElement(
   el: Element
 ): ReturnType<typeof analyzeVisualization> | undefined {
@@ -8,9 +15,71 @@ function inspectSelectedElement(
   }
 }
 
+/**
+ * A type guard to assert that an element is an SVG element.
+ *
+ * @param el – The element to check.
+ * @returns – True if the element is an SVG element, otherwise false. In addition,
+ * TypeScript will narrow the type of the element to SVGSVGElement.
+ */
 function isSVGElement(el: Element): el is SVGSVGElement {
   return el.nodeName === 'svg';
 }
+
+// The class name to apply to an element when hovered.
+const MOUSE_VISITED_CLASSNAME = 'mouse-visited';
+
+function onMouseEnter(event: MouseEvent) {
+  // We only add the mouseenter event listener to SVG elements, making this cast
+  // safe.
+  const el = event.target as SVGSVGElement;
+
+  // Add a visited class name to the element so we can style it.
+  el.classList.add(MOUSE_VISITED_CLASSNAME);
+}
+
+function onMouseLeave(event: MouseEvent) {
+  // We only add the mouseleave event listener to SVG elements, making this cast
+  // safe.
+  const el = event.target as SVGSVGElement;
+
+  // Remove the visited class name from the element so we can style it.
+  el.classList.remove(MOUSE_VISITED_CLASSNAME);
+}
+
+function onClick(event: MouseEvent) {
+  const el = event.target as SVGSVGElement;
+
+  // Analyze the visualzation and send the result to the service worker, which
+  // will forward it to the DevTools page.
+  chrome.runtime.sendMessage(analyzeVisualization(el));
+}
+
+/**
+ * Activate the inspector by adding a mousemove event listener to the inspected
+ * document.
+ */
+function activateInspector() {
+  document.querySelectorAll('svg').forEach((el) => {
+    el.addEventListener('mouseenter', onMouseEnter);
+    el.addEventListener('mouseleave', onMouseLeave);
+    el.addEventListener('click', onClick);
+  });
+}
+
+/**
+ * Deactivate the inspector by removing the mousemove event listener from the
+ * inspected document.
+ */
+function deactivateInspector() {
+  document.querySelectorAll('svg').forEach((el) => {
+    el.removeEventListener('mouseenter', onMouseEnter);
+    el.removeEventListener('mouseleave', onMouseLeave);
+    el.removeEventListener('click', onClick);
+  });
+}
+
+// Attach event listeners to all SVG elements in the inspected document.
 
 // This is a bit goofy — allow me to explain. vite + esbuild optimize away this
 // entire module because (1) it's not imported anywhere and (2) even as an
@@ -21,5 +90,25 @@ function isSVGElement(el: Element): el is SVGSVGElement {
   window as Window &
     typeof globalThis & {
       inspectSelectedElement: typeof inspectSelectedElement;
+      activateInspector: typeof activateInspector;
+      deactivateInspector: typeof deactivateInspector;
     }
 ).inspectSelectedElement = inspectSelectedElement;
+
+(
+  window as Window &
+    typeof globalThis & {
+      inspectSelectedElement: typeof inspectSelectedElement;
+      activateInspector: typeof activateInspector;
+      deactivateInspector: typeof deactivateInspector;
+    }
+).activateInspector = activateInspector;
+
+(
+  window as Window &
+    typeof globalThis & {
+      inspectSelectedElement: typeof inspectSelectedElement;
+      activateInspector: typeof activateInspector;
+      deactivateInspector: typeof deactivateInspector;
+    }
+).deactivateInspector = deactivateInspector;

--- a/extension/scripts/service-worker.ts
+++ b/extension/scripts/service-worker.ts
@@ -1,0 +1,49 @@
+// Skeleton implementation taken from:
+// https://developer.chrome.com/docs/extensions/mv3/devtools/#content-script-to-devtools
+const connections: Record<number, chrome.runtime.Port> = {};
+
+chrome.runtime.onConnect.addListener((port) => {
+  const extensionListener = (message: { name: string; tabId: number }) => {
+    // The original connection event doesn't include the tabId of the DevTools
+    // page, so we need to send it explicitly.
+    if (message.name === 'init') {
+      connections[message.tabId] = port;
+      return;
+    }
+  };
+
+  port.onMessage.addListener(extensionListener);
+
+  port.onDisconnect.addListener((port) => {
+    // Remove the extension listener on port disconnect.
+    port.onMessage.removeListener(extensionListener);
+
+    // Delete the reference to the port in the connections object.
+    const tabs = Object.keys(connections).map((id) => +id);
+
+    for (let i = 0, len = tabs.length; i < len; i++) {
+      if (connections[tabs[i]] === port) {
+        delete connections[tabs[i]];
+        break;
+      }
+    }
+  });
+});
+
+// When we receive a message from the content script, forward it to the
+// DevTools page to handle.
+chrome.runtime.onMessage.addListener((request, sender) => {
+  if (sender.tab) {
+    const tabId = sender.tab.id;
+
+    if (tabId && tabId in connections) {
+      connections[tabId].postMessage(request);
+    } else {
+      console.log('Tab not found in connection list.');
+    }
+  } else {
+    console.log('sender.tab not defined.');
+  }
+
+  return true;
+});

--- a/extension/scripts/service-worker.ts
+++ b/extension/scripts/service-worker.ts
@@ -1,5 +1,7 @@
-// Skeleton implementation taken from:
-// https://developer.chrome.com/docs/extensions/mv3/devtools/#content-script-to-devtools
+/**
+ * Skeleton implementation taken from:
+ * https://developer.chrome.com/docs/extensions/mv3/devtools/#content-script-to-devtools
+ */
 const connections: Record<number, chrome.runtime.Port> = {};
 
 chrome.runtime.onConnect.addListener((port) => {
@@ -30,8 +32,8 @@ chrome.runtime.onConnect.addListener((port) => {
   });
 });
 
-// When we receive a message from the content script, forward it to the
-// DevTools page to handle.
+// When we receive a message from the content script, forward it to the DevTools
+// page to handle.
 chrome.runtime.onMessage.addListener((request, sender) => {
   if (sender.tab) {
     const tabId = sender.tab.id;

--- a/extension/src/App.tsx
+++ b/extension/src/App.tsx
@@ -5,7 +5,6 @@ import ExtensionErrorBoundary from './components/ExtensionErrorBoundary';
 
 function App() {
   const [program, setProgram] = React.useState<string>('');
-  const [error] = React.useState<string>('');
 
   React.useEffect(() => {
     // Establish a long-lived connection to the service worker.
@@ -26,17 +25,13 @@ function App() {
 
   return (
     <main className="p-4 bg-slate-900 absolute inset-0 text-white">
-      {error ? (
-        <p>An error occurred.</p>
-      ) : (
-        <ExtensionErrorBoundary
-          fallback={(message) => <p>An error occurred. {message}</p>}
-        >
-          <ElementSelect />
-        </ExtensionErrorBoundary>
-      )}
-      <p>Program:</p>
-      <pre>{program}</pre>
+      <ExtensionErrorBoundary
+        fallback={(message) => <p>An error occurred. {message}</p>}
+      >
+        <ElementSelect />
+        <p>Program:</p>
+        <pre>{program}</pre>
+      </ExtensionErrorBoundary>
     </main>
   );
 }

--- a/extension/src/components/ElementSelect.tsx
+++ b/extension/src/components/ElementSelect.tsx
@@ -22,9 +22,19 @@ const ElementSelect: React.FC = () => {
   const [isElementSelectActive, setElementSelectActive] = React.useState(false);
 
   function toggleElementSelectActive() {
-    setElementSelectActive(
-      (prevElementSelectActive) => !prevElementSelectActive
-    );
+    setElementSelectActive((prevElementSelectActive) => {
+      if (prevElementSelectActive) {
+        chrome.devtools.inspectedWindow.eval('deactivateInspector()', {
+          useContentScriptContext: true,
+        });
+      } else {
+        chrome.devtools.inspectedWindow.eval('activateInspector()', {
+          useContentScriptContext: true,
+        });
+      }
+
+      return !prevElementSelectActive;
+    });
   }
 
   return (

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -12,10 +12,14 @@ export default defineConfig({
         devtools: resolve(__dirname, 'devtools.html'),
         panel: resolve(__dirname, 'panel.html'),
         inspect: resolve(__dirname, 'scripts', 'inspect.ts'),
+        'service-worker': resolve(__dirname, 'scripts', 'service-worker.ts'),
       },
       output: {
         entryFileNames: (chunkInfo: PreRenderedChunk) =>
-          chunkInfo.name.includes('inspect') ? '[name].js' : '[name]-[hash].js',
+          chunkInfo.name.includes('inspect') ||
+          chunkInfo.name.includes('service-worker')
+            ? '[name].js'
+            : '[name]-[hash].js',
       },
     },
   },


### PR DESCRIPTION
This PR adds a service worker to support message passing between the content script and the DevTools panel, following [the implementation](https://developer.chrome.com/docs/extensions/mv3/devtools/#content-script-to-devtools) described in the Chrome team's Extensions doc. At a high-level, this implementation:

- Adds state to track whether element selection is active or not.
- When element selection is active, renders selection outlines around SVG elements on hover.
- On click, calls `reviz`'s `analyzeVisualization` function.
- Sends the result of calling `analyzeVisualization` to the service worker.
- The service worker forwards the result to the DevTools panel via a long-lived connection.
- The DevTools panel now has access to the spec and partial program!

Our original implementation planned to just call `chrome.devtools.inspectedWindow.eval` on click of an SVG element, but this approach has a few problems.

1. It's difficult to inject callbacks into a content script. We can listen for `'click'` events within a content script and even pass a simple callback into them. However, the callback we pass cannot close over any functions defined in the DevTools panel. This means we cannot do things like set local React state in our DevTools panel in response to events.
2. The architecture of Chrome extensions discourages any notion of shared state in favor of message passing. Even if we could somehow `eval` code with the proper event listener registration and de-registration, getting the result of `analyzeVisualization` back into our DevTools panel could be tricky.

This implementation, while a bit verbose, uses the API as inteded.