### PR TITLE
Fix #12. Render the output of the filled program.

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -16,5 +16,8 @@
   ],
   "background": {
     "service_worker": "service-worker.js"
+  },
+  "sandbox": {
+    "pages": ["sandbox.html"]
   }
 }

--- a/extension/sandbox.html
+++ b/extension/sandbox.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <script type="module" src="/scripts/sandbox.ts"></script>
+  </body>
+</html>

--- a/extension/scripts/sandbox.ts
+++ b/extension/scripts/sandbox.ts
@@ -1,15 +1,9 @@
 import * as Plot from "@observablehq/plot";
 
-import { Data } from "../src/types/data";
+import type { ExecuteMessage } from "../src/types/message";
 import { formatExecutableProgram } from "../src/utils/formatters";
 
-interface RenderMessage {
-  name: "execute";
-  data: Data;
-  program: string;
-}
-
-window.addEventListener("message", (event: MessageEvent<RenderMessage>) => {
+window.addEventListener("message", (event: MessageEvent<ExecuteMessage>) => {
   if (event.data.name !== "execute") {
     return;
   }

--- a/extension/scripts/sandbox.ts
+++ b/extension/scripts/sandbox.ts
@@ -1,0 +1,34 @@
+import * as Plot from "@observablehq/plot";
+
+import { Data } from "../src/types/data";
+import { formatExecutableProgram } from "../src/utils/formatters";
+
+interface RenderMessage {
+  name: "execute";
+  data: Data;
+  program: string;
+}
+
+window.addEventListener("message", (event: MessageEvent<RenderMessage>) => {
+  if (event.data.name !== "execute") {
+    return;
+  }
+
+  const { data, program } = event.data;
+  try {
+    const plot = Function(`return ${formatExecutableProgram(program)}`)()(
+      Plot,
+      data
+    ) as SVGSVGElement;
+
+    event.source?.postMessage(
+      {
+        name: "render",
+        plot: plot.outerHTML,
+      },
+      { targetOrigin: event.origin }
+    );
+  } catch (err) {
+    console.error(err);
+  }
+});

--- a/extension/src/App.tsx
+++ b/extension/src/App.tsx
@@ -27,6 +27,7 @@ function App() {
       classNames: "",
     });
   const [data, setData] = React.useState<Data>();
+  const [output, setOutput] = React.useState<string>("");
 
   React.useEffect(() => {
     // Establish a long-lived connection to the service worker.
@@ -82,8 +83,12 @@ function App() {
             value="visualize"
             className="tab-content flex grow flex-col overflow-hidden lg:flex-row"
           >
-            <ProgramOutput program={program} data={data} />
-            <ProgramEditor program={program} />
+            <ProgramOutput output={output} />
+            <ProgramEditor
+              program={program}
+              data={data}
+              setOutput={setOutput}
+            />
             <DataPanel data={data} setData={setData} />
           </Tabs.Content>
         </Tabs.Root>

--- a/extension/src/components/data/DataGrid.tsx
+++ b/extension/src/components/data/DataGrid.tsx
@@ -34,7 +34,7 @@ const DataGrid: React.FC<Props> = ({ data }) => {
   });
 
   return (
-    <div className="overflow-auto">
+    <div className="-mx-3 -mb-2 overflow-auto">
       <table className="data-grid relative border-collapse font-mono">
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/extension/src/components/data/DataPanel.tsx
+++ b/extension/src/components/data/DataPanel.tsx
@@ -11,8 +11,8 @@ interface Props {
 
 const DataPanel: React.FC<Props> = ({ data, setData }) => {
   return (
-    <div className="stack stack-sm shrink-0 basis-1/3 overflow-hidden px-3 py-2">
-      <Heading className="self-start">Data</Heading>
+    <div className="flex shrink-0 basis-1/3 flex-col overflow-hidden px-3 py-2">
+      <Heading className="mb-4 self-start">Data</Heading>
       {data ? <DataGrid data={data} /> : <DataUpload setData={setData} />}
     </div>
   );

--- a/extension/src/components/program/ProgramEditor.tsx
+++ b/extension/src/components/program/ProgramEditor.tsx
@@ -58,7 +58,7 @@ const ProgramEditor: React.FC<Props> = ({ program, data, setOutput }) => {
         "*"
       );
     }
-  }, [program, data]);
+  }, [data]);
 
   return (
     <div className="relative flex shrink-0 basis-1/3 flex-col overflow-hidden border-b border-slate-500 px-3 py-2 lg:border-b-0 lg:border-r">
@@ -67,7 +67,6 @@ const ProgramEditor: React.FC<Props> = ({ program, data, setOutput }) => {
         <div
           ref={editorRef}
           className="relative -mx-3 -mb-2 h-full overflow-auto bg-white text-xs text-black"
-          style={{ marginBottom: "-0.75rem !important" }}
         >
           <button
             onClick={onExecute}

--- a/extension/src/components/program/ProgramEditor.tsx
+++ b/extension/src/components/program/ProgramEditor.tsx
@@ -59,12 +59,13 @@ const ProgramEditor: React.FC<Props> = ({ program, data, setOutput }) => {
   }, [program, data]);
 
   return (
-    <div className="stack stack-sm relative shrink-0 basis-1/3 overflow-hidden border-b border-slate-500 px-3 py-2 lg:border-b-0 lg:border-r">
-      <Heading className="self-start">Program</Heading>
+    <div className="relative flex shrink-0 basis-1/3 flex-col overflow-hidden border-b border-slate-500 px-3 py-2 lg:border-b-0 lg:border-r">
+      <Heading className="mb-4 self-start">Program</Heading>
       {program ? (
         <div
           ref={editorRef}
-          className="relative -mx-3 h-full overflow-auto bg-white text-xs text-black"
+          className="relative -mx-3 -mb-2 h-full overflow-auto bg-white text-xs text-black"
+          style={{ marginBottom: "-0.75rem !important" }}
         >
           <button
             onClick={onExecute}
@@ -87,7 +88,13 @@ const ProgramEditor: React.FC<Props> = ({ program, data, setOutput }) => {
       ) : (
         <p>Waiting for visualization selection...</p>
       )}
-      <iframe ref={iframeRef} src="/sandbox.html" width={0} height={0} />
+      <iframe
+        ref={iframeRef}
+        src="/sandbox.html"
+        className="hidden"
+        width={0}
+        height={0}
+      />
     </div>
   );
 };

--- a/extension/src/components/program/ProgramEditor.tsx
+++ b/extension/src/components/program/ProgramEditor.tsx
@@ -4,25 +4,59 @@ import { javascript } from "@codemirror/lang-javascript";
 
 import Heading from "../shared/Heading";
 import { formatProgram } from "../../utils/formatters";
+import { Data } from "../../types/data";
 
 interface Props {
   program: string;
+  data?: Data;
+  setOutput: (output: string) => void;
 }
 
-const ProgramEditor: React.FC<Props> = ({ program }) => {
+const ProgramEditor: React.FC<Props> = ({ program, data, setOutput }) => {
   const editorRef = React.useRef<HTMLDivElement>(null);
+  let editor = React.useRef<EditorView>();
 
   React.useEffect(() => {
-    const editor = new EditorView({
+    const ed = new EditorView({
       extensions: [basicSetup, javascript()],
       parent: editorRef.current!,
       doc: formatProgram(program),
     });
 
+    editor.current = ed;
+
     return () => {
-      editor.destroy();
+      ed.destroy();
+      editor.current = undefined;
     };
   }, [program]);
+
+  React.useEffect(() => {
+    window.addEventListener(
+      "message",
+      (event: MessageEvent<{ name: "render"; plot: string }>) => {
+        if (event.data.name !== "render") {
+          return;
+        }
+
+        setOutput(event.data.plot);
+      }
+    );
+  }, []);
+
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
+  const onExecute = React.useCallback(() => {
+    if (iframeRef.current && data) {
+      iframeRef.current.contentWindow?.postMessage(
+        {
+          name: "execute",
+          program: editor.current?.state.doc.toString() ?? "",
+          data: data.data,
+        },
+        "*"
+      );
+    }
+  }, [program, data]);
 
   return (
     <div className="stack stack-sm relative shrink-0 basis-1/3 overflow-hidden border-b border-slate-500 px-3 py-2 lg:border-b-0 lg:border-r">
@@ -30,11 +64,30 @@ const ProgramEditor: React.FC<Props> = ({ program }) => {
       {program ? (
         <div
           ref={editorRef}
-          className="-mx-3 h-full overflow-auto bg-white text-xs text-black"
-        />
+          className="relative -mx-3 h-full overflow-auto bg-white text-xs text-black"
+        >
+          <button
+            onClick={onExecute}
+            className="absolute right-4 top-1 z-10 text-gray-500"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              strokeWidth="1"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m5 3 14 9-14 9V3z" />
+            </svg>
+          </button>
+        </div>
       ) : (
         <p>Waiting for visualization selection...</p>
       )}
+      <iframe ref={iframeRef} src="/sandbox.html" width={0} height={0} />
     </div>
   );
 };

--- a/extension/src/components/program/ProgramOutput.tsx
+++ b/extension/src/components/program/ProgramOutput.tsx
@@ -1,20 +1,19 @@
 import * as React from "react";
 
 import Heading from "../shared/Heading";
-import type { Data } from "../../types/data";
 
 interface Props {
-  program: string;
-  data: Data;
+  output: string;
 }
 
-const ProgramOutput: React.FC<Props> = () => {
-  const outputRef = React.useRef<HTMLDivElement>(null);
-
+const ProgramOutput: React.FC<Props> = ({ output }) => {
   return (
     <div className="stack stack-sm relative shrink-0 basis-1/3 overflow-hidden border-b border-slate-500 px-3 py-2 lg:border-b-0 lg:border-r">
       <Heading className="self-start">Program Output</Heading>
-      <div ref={outputRef} className="overflow-auto" />
+      <div
+        dangerouslySetInnerHTML={{ __html: output }}
+        className="overflow-auto text-black"
+      />
     </div>
   );
 };

--- a/extension/src/components/program/ProgramOutput.tsx
+++ b/extension/src/components/program/ProgramOutput.tsx
@@ -8,11 +8,11 @@ interface Props {
 
 const ProgramOutput: React.FC<Props> = ({ output }) => {
   return (
-    <div className="stack stack-sm relative shrink-0 basis-1/3 overflow-hidden border-b border-slate-500 px-3 py-2 lg:border-b-0 lg:border-r">
-      <Heading className="self-start">Program Output</Heading>
+    <div className="relative flex shrink-0 basis-1/3 flex-col overflow-hidden border-b border-slate-500 px-3 py-2 lg:border-b-0 lg:border-r">
+      <Heading className="mb-4 self-start">Program Output</Heading>
       <div
         dangerouslySetInnerHTML={{ __html: output }}
-        className="overflow-auto text-black"
+        className="-mx-3 -mb-2 overflow-auto text-black"
       />
     </div>
   );

--- a/extension/src/components/program/ProgramViewer.tsx
+++ b/extension/src/components/program/ProgramViewer.tsx
@@ -11,8 +11,8 @@ interface Props {
 
 const ProgramViewer: React.FC<Props> = ({ program }) => {
   return (
-    <div className="stack stack-sm relative basis-1/2 px-3 py-2">
-      <Heading className="self-start">Program</Heading>
+    <div className="relative flex basis-1/2 flex-col px-3 py-2">
+      <Heading className="mb-4 self-start">Program</Heading>
       {program ? (
         <Highlight
           code={formatProgram(program)}
@@ -21,7 +21,10 @@ const ProgramViewer: React.FC<Props> = ({ program }) => {
         >
           {({ className, style, tokens, getLineProps, getTokenProps }) => (
             <pre
-              className={cs("-mx-3 overflow-auto px-3 py-2 text-xs", className)}
+              className={cs(
+                "-mx-3 -mb-2 overflow-auto px-3 py-2 text-xs",
+                className
+              )}
               style={style}
             >
               {tokens.map((line, i) => (

--- a/extension/src/components/program/ProgramViewer.tsx
+++ b/extension/src/components/program/ProgramViewer.tsx
@@ -22,7 +22,7 @@ const ProgramViewer: React.FC<Props> = ({ program }) => {
           {({ className, style, tokens, getLineProps, getTokenProps }) => (
             <pre
               className={cs(
-                "-mx-3 -mb-2 overflow-auto px-3 py-2 text-xs",
+                "-mx-3 -mb-2 flex-1 overflow-auto px-3 py-2 text-xs",
                 className
               )}
               style={style}

--- a/extension/src/types/message.ts
+++ b/extension/src/types/message.ts
@@ -1,0 +1,12 @@
+import type { Data } from "./data";
+
+export interface ExecuteMessage {
+  name: "execute";
+  data: Data;
+  program: string;
+}
+
+export interface RenderMessage {
+  name: "render";
+  plot: string;
+}

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       input: {
         devtools: resolve(__dirname, "devtools.html"),
         panel: resolve(__dirname, "panel.html"),
+        sandbox: resolve(__dirname, "sandbox.html"),
         inspect: resolve(__dirname, "scripts", "inspect.ts"),
         "service-worker": resolve(__dirname, "scripts", "service-worker.ts"),
       },


### PR DESCRIPTION
This PR adds support for rendering the output of the filled program generated by `reviz` directly in the extension.

<img width="1516" alt="image" src="https://github.com/parkerziegler/reviz/assets/19421190/f41dad39-8f51-47f5-ae2b-f179ce717780">

The implementation here hues very closely to the steps described in #12. We create a new "sandbox" page as an isolated environment in which to evaluate the filled program—modeled as a string—with user uploaded data. We use standard message passing between the extension's main thread and the "sandbox" page (loaded via an invisible `iframe`) to pass the user program and data in and the serialized HTML of the resulting visualization out. Finally, we render the resulting HTML using React's [`dangerouslySetInnerHTML`](https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html).

We need to rethink this final step. Because we allow arbitrary JS to be entered into the extension code editor currently, attackers could find ways to write JS programs that alter the HTML returned by Plot. For now, this is just enough to get the entire flow working.
