### PR TITLE
extension: Add custom CodeMirror theme inspired by Night Owl.

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -31,6 +31,7 @@
     "@codemirror/lang-javascript": "^6.1.9",
     "@observablehq/plot": "^0.6.9",
     "@radix-ui/react-tabs": "^1.0.4",
+    "@radix-ui/react-tooltip": "^1.0.6",
     "@reviz/compiler": "^0.5.0",
     "@reviz/ui": "^0.5.0",
     "@tanstack/react-table": "^8.9.3",

--- a/packages/extension/src/App.tsx
+++ b/packages/extension/src/App.tsx
@@ -67,7 +67,7 @@ const App: React.FC = () => {
         >
           <div className="flex border-b border-b-slate-500">
             <ElementSelect nodeName={nodeName} classNames={classNames} />
-            <Tabs.List className="flex shrink-0">
+            <Tabs.List className="flex shrink-0 font-mono">
               <Tabs.Trigger
                 className="tab-trigger border-r border-slate-500 px-3 py-2 text-sm"
                 value="analyze"
@@ -84,7 +84,7 @@ const App: React.FC = () => {
           </div>
           <Tabs.Content
             value="analyze"
-            className="tab-content flex grow flex-col lg:flex-row"
+            className="tab-content flex grow flex-col overflow-hidden lg:flex-row"
           >
             <SpecViewer spec={spec} />
             <ProgramViewer program={program} />

--- a/packages/extension/src/components/data/DataUpload.tsx
+++ b/packages/extension/src/components/data/DataUpload.tsx
@@ -7,6 +7,127 @@ interface Props {
   setData: (data: Data) => void;
 }
 
+const UploadIcon = (
+  <svg
+    width="148"
+    height="56"
+    viewBox="0 0 148 56"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M81.5 30.5V33.8333C81.5 34.2754 81.3244 34.6993 81.0118 35.0118C80.6993 35.3244 80.2754 35.5 79.8333 35.5H68.1667C67.7246 35.5 67.3007 35.3244 66.9882 35.0118C66.6756 34.6993 66.5 34.2754 66.5 33.8333V30.5"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M78.1667 24.6667L74 20.5L69.8333 24.6667"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M74 20.5V30.5"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <rect
+      x="9.20855"
+      y="13.1552"
+      width="39"
+      height="55"
+      rx="1.5"
+      transform="rotate(-12 9.20855 13.1552)"
+      stroke="currentColor"
+    />
+    <path
+      d="M33.1551 46.5108L31.5962 46.8422C28.8108 47.4342 27.7406 46.7392 27.1388 43.9079L26.593 41.3403C26.2178 39.575 24.9668 38.7627 22.3431 39.6079L21.9021 37.5332C24.6428 37.2382 25.4576 35.9987 25.0799 34.222L24.5342 31.6543C23.9324 28.8231 24.6274 27.7528 27.4128 27.1608L28.9717 26.8294L29.3055 28.3998L28.0561 28.6654C26.3367 29.0308 26.0896 29.5027 26.5135 31.4972L27.164 34.5577C27.5051 36.1625 26.5282 37.4844 24.2134 38.0363L24.2524 38.2197C26.5891 37.7709 28.0192 38.5811 28.3603 40.1859L29.0109 43.2464C29.4348 45.2409 29.8525 45.5715 31.5719 45.206L32.8213 44.9404L33.1551 46.5108ZM38.726 45.3267L38.3922 43.7563L39.6416 43.4907C41.361 43.1253 41.6082 42.6534 41.1842 40.6589L40.5337 37.5984C40.1926 35.9936 41.1696 34.6717 43.4868 34.1313L43.4478 33.9479C41.1087 34.3852 39.6785 33.575 39.3374 31.9702L38.6869 28.9097C38.2629 26.9152 37.8452 26.5846 36.1258 26.9501L34.8764 27.2157L34.5426 25.6453L36.1015 25.3139C38.8869 24.7219 39.9572 25.4169 40.559 28.2482L41.1047 30.8158C41.4824 32.5925 42.7309 33.3934 45.3547 32.5482L45.7957 34.6229C43.0549 34.9179 42.2426 36.1689 42.6178 37.9341L43.1636 40.5018C43.7654 43.333 43.0703 44.4033 40.2849 44.9953L38.726 45.3267Z"
+      fill="currentColor"
+    />
+    <rect
+      x="0.59303"
+      y="-0.385118"
+      width="39"
+      height="55"
+      rx="1.5"
+      transform="matrix(0.978148 0.207912 0.207912 -0.978148 88.7086 58.3448)"
+      stroke="currentColor"
+    />
+    <line
+      x1="102.104"
+      y1="14.5109"
+      x2="115.798"
+      y2="17.4217"
+      stroke="currentColor"
+    />
+    <line
+      x1="119.711"
+      y1="18.2533"
+      x2="133.405"
+      y2="21.1641"
+      stroke="currentColor"
+    />
+    <line
+      x1="100.441"
+      y1="22.3361"
+      x2="114.135"
+      y2="25.2469"
+      stroke="currentColor"
+    />
+    <line
+      x1="118.047"
+      y1="26.0785"
+      x2="131.741"
+      y2="28.9893"
+      stroke="currentColor"
+    />
+    <line
+      x1="98.7774"
+      y1="30.1613"
+      x2="112.471"
+      y2="33.072"
+      stroke="currentColor"
+    />
+    <line
+      x1="116.384"
+      y1="33.9037"
+      x2="130.078"
+      y2="36.8145"
+      stroke="currentColor"
+    />
+    <line
+      x1="97.1141"
+      y1="37.9865"
+      x2="110.808"
+      y2="40.8972"
+      stroke="currentColor"
+    />
+    <line
+      x1="114.721"
+      y1="41.7289"
+      x2="128.415"
+      y2="44.6396"
+      stroke="currentColor"
+    />
+    <line
+      x1="95.4508"
+      y1="45.8116"
+      x2="109.145"
+      y2="48.7224"
+      stroke="currentColor"
+    />
+    <line
+      x1="113.057"
+      y1="49.5541"
+      x2="126.752"
+      y2="52.4648"
+      stroke="currentColor"
+    />
+  </svg>
+);
+
 const DataUpload: React.FC<Props> = ({ setData }) => {
   const onChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -65,21 +186,7 @@ const DataUpload: React.FC<Props> = ({ setData }) => {
 
   return (
     <div className="flex h-full flex-col items-center justify-center border border-dashed border-slate-500">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-        <polyline points="17 8 12 3 7 8"></polyline>
-        <line x1="12" y1="3" x2="12" y2="15"></line>
-      </svg>
+      {UploadIcon}
       <p className="mt-2 text-sm">
         Upload a{' '}
         <label className="border-primary text-primary relative cursor-pointer border-b border-dotted">
@@ -89,7 +196,7 @@ const DataUpload: React.FC<Props> = ({ setData }) => {
             className="absolute h-full w-full opacity-[0.0001]"
             onChange={onChange}
           />
-          CSV
+          JSON
         </label>{' '}
         or{' '}
         <label className="border-primary text-primary relative cursor-pointer border-b border-dotted">
@@ -99,9 +206,9 @@ const DataUpload: React.FC<Props> = ({ setData }) => {
             className="absolute h-full w-full opacity-[0.0001]"
             onChange={onChange}
           />
-          JSON
+          CSV
         </label>{' '}
-        file.
+        file
       </p>
     </div>
   );

--- a/packages/extension/src/components/interaction/ElementSelect.tsx
+++ b/packages/extension/src/components/interaction/ElementSelect.tsx
@@ -1,23 +1,30 @@
 import * as React from 'react';
 import cs from 'classnames';
+import * as Tooltip from '@radix-ui/react-tooltip';
 
 import type { VisualizationState } from '../../App';
 import { formatClassNames } from '../../utils/formatters';
 
+import ElementSelectPrompt from './ElementSelectPrompt';
+
 const MousePointer = (
   <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="16"
-    height="16"
+    width="20"
+    height="20"
     viewBox="0 0 24 24"
     fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
+    xmlns="http://www.w3.org/2000/svg"
   >
-    <path d="M3 3l7.07 16.97 2.51-7.39 7.39-2.51L3 3z"></path>
-    <path d="M13 13l6 6"></path>
+    <path
+      d="M16.3636 24H0V0H24V16.3636"
+      stroke="currentColor"
+      stroke-dasharray="2 3"
+    />
+    <path
+      d="M10 20L5 5L20 10L13 13L10 20Z"
+      stroke="currentColor"
+      stroke-linejoin="round"
+    />
   </svg>
 );
 
@@ -43,31 +50,39 @@ const ElementSelect: React.FC<Props> = ({ nodeName, classNames }) => {
   }
 
   return (
-    <div className="flex flex-1 overflow-hidden border-r border-slate-500">
-      <button
-        onClick={toggleElementSelectActive}
-        className={cs(
-          'border-r border-r-slate-500 px-3 py-2 transition-opacity hover:opacity-75',
-          isElementSelectActive ? 'text-blue-400' : 'text-white'
-        )}
-      >
-        {MousePointer}
-      </button>
+    <div className="flex flex-1 overflow-hidden border-r border-slate-500 py-2">
+      <Tooltip.Provider>
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <button
+              onClick={toggleElementSelectActive}
+              className={cs(
+                'border-r border-r-slate-500 px-3 transition-opacity hover:opacity-75',
+                isElementSelectActive ? 'text-blue-400' : 'text-white'
+              )}
+            >
+              {MousePointer}
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content className="tooltip-content" side="bottom">
+              <p className="text-primary rounded bg-blue-50 px-2 py-1 font-mono shadow-md">
+                {isElementSelectActive ? 'Disable' : 'Enable'} SVG selector
+              </p>
+              <Tooltip.Arrow className="fill-blue-50" />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </Tooltip.Provider>
       {nodeName ? (
-        <p className="text-primary flex truncate px-3 py-2">
+        <p className="text-primary flex truncate px-3">
           <code className="truncate rounded bg-blue-50 px-1 py-0.5">
             <span className="text-secondary">{nodeName}</span>
             {classNames ? <span>{formatClassNames(classNames)}</span> : null}
           </code>
         </p>
       ) : (
-        <p className="px-3 py-2">
-          Select an{' '}
-          <code className="text-primary rounded bg-blue-50 px-1 py-0.5">
-            svg
-          </code>{' '}
-          element to inspect.
-        </p>
+        <ElementSelectPrompt className="px-3" />
       )}
     </div>
   );

--- a/packages/extension/src/components/interaction/ElementSelect.tsx
+++ b/packages/extension/src/components/interaction/ElementSelect.tsx
@@ -3,6 +3,7 @@ import cs from 'classnames';
 import * as Tooltip from '@radix-ui/react-tooltip';
 
 import type { VisualizationState } from '../../App';
+import TooltipMessage from '../shared/TooltipMessage';
 import { formatClassNames } from '../../utils/formatters';
 
 import ElementSelectPrompt from './ElementSelectPrompt';
@@ -66,9 +67,9 @@ const ElementSelect: React.FC<Props> = ({ nodeName, classNames }) => {
           </Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Content className="tooltip-content" side="bottom">
-              <p className="text-primary rounded bg-blue-50 px-2 py-1 font-mono shadow-md">
+              <TooltipMessage>
                 {isElementSelectActive ? 'Disable' : 'Enable'} SVG selector
-              </p>
+              </TooltipMessage>
               <Tooltip.Arrow className="fill-blue-50" />
             </Tooltip.Content>
           </Tooltip.Portal>

--- a/packages/extension/src/components/interaction/ElementSelectPrompt.tsx
+++ b/packages/extension/src/components/interaction/ElementSelectPrompt.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  className?: string;
+}
+
+const ElementSelectPrompt: React.FC<Props> = ({ className }) => {
+  return (
+    <p className={className}>
+      Select an{' '}
+      <code className="text-primary rounded bg-blue-50 px-1 py-0.5">svg</code>{' '}
+      element to inspect.
+    </p>
+  );
+};
+
+export default ElementSelectPrompt;

--- a/packages/extension/src/components/program/ProgramEditor.tsx
+++ b/packages/extension/src/components/program/ProgramEditor.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 import { EditorView, basicSetup } from 'codemirror';
 import { javascript } from '@codemirror/lang-javascript';
 import { syntaxHighlighting } from '@codemirror/language';
+import * as Tooltip from '@radix-ui/react-tooltip';
 
+import ElementSelectPrompt from '../interaction/ElementSelectPrompt';
 import Heading from '../shared/Heading';
+import { usePrevious } from '../../hooks/usePrevious';
 import type { Data } from '../../types/data';
 import type { RenderMessage } from '../../types/message';
 import { formatProgram } from '../../utils/formatters';
-import { usePrevious } from '../../hooks/usePrevious';
 
 import { syntaxTheme, editorTheme } from './theme';
 
@@ -33,6 +35,8 @@ const ProgramEditor: React.FC<Props> = ({
   const editor = React.useRef<EditorView>();
   const prevDimensions = usePrevious(dimensions);
 
+  const [edited, setEdited] = React.useState(false);
+
   // Initialize the editor.
   React.useEffect(() => {
     if (editorRef.current) {
@@ -42,6 +46,11 @@ const ProgramEditor: React.FC<Props> = ({
           editorTheme,
           javascript(),
           syntaxHighlighting(syntaxTheme),
+          EditorView.updateListener.of((v) => {
+            if (v.docChanged) {
+              setEdited(true);
+            }
+          }),
         ],
         parent: editorRef.current,
         doc: formatProgram(program),
@@ -84,6 +93,7 @@ const ProgramEditor: React.FC<Props> = ({
         },
         '*'
       );
+      setEdited(false);
     }
   }, [data, dimensions]);
 
@@ -104,32 +114,50 @@ const ProgramEditor: React.FC<Props> = ({
 
   return (
     <div className="relative flex shrink-0 basis-1/3 flex-col overflow-hidden border-b border-slate-500 px-3 py-2 lg:border-b-0 lg:border-r">
-      <Heading className="mb-4 self-start">Program</Heading>
+      <div className="mb-4 flex items-center justify-between">
+        <Heading className="self-start">Program</Heading>
+        {program ? (
+          <Tooltip.Provider>
+            <Tooltip.Root>
+              <Tooltip.Trigger asChild>
+                <button
+                  onClick={onExecute}
+                  className="text-primary transition-opacity hover:opacity-75"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill={edited ? 'currentColor' : 'transparent'}
+                    stroke="currentColor"
+                    strokeWidth="1"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="m5 3 14 9-14 9V3z" />
+                  </svg>
+                </button>
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Content className="tooltip-content" side="left">
+                  <p className="text-primary rounded bg-blue-50 px-2 py-1 font-mono shadow-md">
+                    Run program
+                  </p>
+                  <Tooltip.Arrow className="fill-blue-50" />
+                </Tooltip.Content>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+        ) : null}
+      </div>
       {program ? (
         <div
           ref={editorRef}
           className="text-editor-fg relative -mx-3 -mb-2 h-full overflow-auto bg-slate-900 text-xs"
-        >
-          <button
-            onClick={onExecute}
-            className="absolute right-4 top-1 z-10 text-gray-500"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              strokeWidth="1"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="m5 3 14 9-14 9V3z" />
-            </svg>
-          </button>
-        </div>
+        />
       ) : (
-        <p>Waiting for visualization selection...</p>
+        <ElementSelectPrompt />
       )}
       <iframe
         ref={iframeRef}

--- a/packages/extension/src/components/program/ProgramEditor.tsx
+++ b/packages/extension/src/components/program/ProgramEditor.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
 import { EditorView, basicSetup } from 'codemirror';
 import { javascript } from '@codemirror/lang-javascript';
+import { syntaxHighlighting } from '@codemirror/language';
 
 import Heading from '../shared/Heading';
 import type { Data } from '../../types/data';
 import type { RenderMessage } from '../../types/message';
 import { formatProgram } from '../../utils/formatters';
 import { usePrevious } from '../../hooks/usePrevious';
+
+import { syntaxTheme, editorTheme } from './theme';
 
 interface Props {
   program: string;
@@ -34,7 +37,12 @@ const ProgramEditor: React.FC<Props> = ({
   React.useEffect(() => {
     if (editorRef.current) {
       editor.current = new EditorView({
-        extensions: [basicSetup, javascript()],
+        extensions: [
+          basicSetup,
+          editorTheme,
+          javascript(),
+          syntaxHighlighting(syntaxTheme),
+        ],
         parent: editorRef.current,
         doc: formatProgram(program),
       });
@@ -100,7 +108,7 @@ const ProgramEditor: React.FC<Props> = ({
       {program ? (
         <div
           ref={editorRef}
-          className="relative -mx-3 -mb-2 h-full overflow-auto bg-white text-xs text-black"
+          className="text-editor-fg relative -mx-3 -mb-2 h-full overflow-auto bg-slate-900 text-xs"
         >
           <button
             onClick={onExecute}

--- a/packages/extension/src/components/program/ProgramEditor.tsx
+++ b/packages/extension/src/components/program/ProgramEditor.tsx
@@ -6,6 +6,7 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 
 import ElementSelectPrompt from '../interaction/ElementSelectPrompt';
 import Heading from '../shared/Heading';
+import TooltipMessage from '../shared/TooltipMessage';
 import { usePrevious } from '../../hooks/usePrevious';
 import type { Data } from '../../types/data';
 import type { RenderMessage } from '../../types/message';
@@ -141,9 +142,7 @@ const ProgramEditor: React.FC<Props> = ({
               </Tooltip.Trigger>
               <Tooltip.Portal>
                 <Tooltip.Content className="tooltip-content" side="left">
-                  <p className="text-primary rounded bg-blue-50 px-2 py-1 font-mono shadow-md">
-                    Run program
-                  </p>
+                  <TooltipMessage>Run program</TooltipMessage>
                   <Tooltip.Arrow className="fill-blue-50" />
                 </Tooltip.Content>
               </Tooltip.Portal>

--- a/packages/extension/src/components/program/ProgramViewer.tsx
+++ b/packages/extension/src/components/program/ProgramViewer.tsx
@@ -18,6 +18,7 @@ const ProgramViewer: React.FC<Props> = ({ program }) => {
           theme="dark"
           preClassName="-mx-3 -mb-2 flex-1 overflow-auto px-3 py-2 text-xs"
           name="Program"
+          style={{ backgroundColor: '#0f172a' }}
         />
       ) : (
         <p>Waiting for visualization selection...</p>

--- a/packages/extension/src/components/program/ProgramViewer.tsx
+++ b/packages/extension/src/components/program/ProgramViewer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { CodePane } from '@reviz/ui';
 
+import ElementSelectPrompt from '../interaction/ElementSelectPrompt';
 import Heading from '../shared/Heading';
 import { formatProgram } from '../../utils/formatters';
 
@@ -21,7 +22,7 @@ const ProgramViewer: React.FC<Props> = ({ program }) => {
           style={{ backgroundColor: '#0f172a' }}
         />
       ) : (
-        <p>Waiting for visualization selection...</p>
+        <ElementSelectPrompt />
       )}
     </div>
   );

--- a/packages/extension/src/components/program/theme.ts
+++ b/packages/extension/src/components/program/theme.ts
@@ -1,0 +1,72 @@
+import { tags } from '@lezer/highlight';
+import { HighlightStyle } from '@codemirror/language';
+import { EditorView } from '@codemirror/view';
+
+export const syntaxTheme = HighlightStyle.define([
+  {
+    tag: [tags.comment, tags.lineComment, tags.blockComment, tags.docComment],
+    color: '#637777',
+  },
+  {
+    tag: [tags.name, tags.propertyName],
+    color: '#80cbc4',
+  },
+  {
+    tag: tags.variableName,
+    color: '#d6deeb',
+  },
+  {
+    tag: [tags.typeName, tags.className, tags.literal, tags.string],
+    color: '#addb67',
+  },
+  {
+    tag: tags.number,
+    color: '#f78c6c',
+  },
+  {
+    tag: tags.bool,
+    color: '#ff5874',
+  },
+  {
+    tag: [tags.keyword, tags.operator],
+    color: '#7fdbca',
+  },
+  {
+    tag: [tags.paren, tags.brace, tags.bracket],
+    color: '#c792ea',
+  },
+  {
+    tag: tags.function(tags.propertyName),
+    color: '#82aaff',
+  },
+]);
+
+export const editorTheme = EditorView.theme(
+  {
+    '&': {
+      height: '100%',
+    },
+    '.cm-scroller': {
+      fontFamily:
+        'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;',
+    },
+    '.cm-gutters': {
+      backgroundColor: '#0f172a',
+      color: '#506377',
+    },
+    '.cm-activeLineGutter': {
+      backgroundColor: '#24395a',
+    },
+    '.cm-activeLine': {
+      backgroundColor: '#24395a',
+    },
+    '.cm-selectionBackground, ::selection': {
+      backgroundColor: '#24395a',
+    },
+    '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground':
+      {
+        backgroundColor: '#24395a',
+      },
+  },
+  { dark: true }
+);

--- a/packages/extension/src/components/program/theme.ts
+++ b/packages/extension/src/components/program/theme.ts
@@ -53,12 +53,14 @@ export const editorTheme = EditorView.theme(
     '.cm-gutters': {
       backgroundColor: '#0f172a',
       color: '#506377',
+      paddingRight: '6px',
     },
     '.cm-activeLineGutter': {
-      backgroundColor: '#24395a',
+      backgroundColor: 'transparent',
+      color: '#d6deeb',
     },
     '.cm-activeLine': {
-      backgroundColor: '#24395a',
+      backgroundColor: 'transparent',
     },
     '.cm-selectionBackground, ::selection': {
       backgroundColor: '#24395a',
@@ -67,6 +69,9 @@ export const editorTheme = EditorView.theme(
       {
         backgroundColor: '#24395a',
       },
+    '&.cm-focused .cm-cursor': {
+      borderLeftColor: '#d6deeb',
+    },
   },
   { dark: true }
 );

--- a/packages/extension/src/components/shared/TooltipMessage.tsx
+++ b/packages/extension/src/components/shared/TooltipMessage.tsx
@@ -1,0 +1,9 @@
+const TooltipMessage: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <p className="text-primary rounded bg-blue-50 px-2 py-1 font-mono shadow-md">
+      {children}
+    </p>
+  );
+};
+
+export default TooltipMessage;

--- a/packages/extension/src/components/spec/ColorValue.tsx
+++ b/packages/extension/src/components/spec/ColorValue.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 const ColorValue: React.FC<Props> = ({ color }) => {
   return (
-    <div className="stack-h stack-h-xs shrink-0 items-center">
+    <div className="stack-h shrink-0 items-center">
       {color !== 'none' ? (
         <span className="h-3 w-3" style={{ backgroundColor: color }} />
       ) : null}

--- a/packages/extension/src/components/spec/SpecViewer.tsx
+++ b/packages/extension/src/components/spec/SpecViewer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { RevizOutput } from '@reviz/compiler';
 
 import { formatOneOrMoreValues } from '../../utils/formatters';
+import ElementSelectPrompt from '../interaction/ElementSelectPrompt';
 import Heading from '../shared/Heading';
 
 interface Props {
@@ -10,10 +11,14 @@ interface Props {
 
 const SpecViewer: React.FC<Props> = ({ spec }) => {
   return (
-    <div className="stack stack-sm basis-1/2 border-b border-slate-500 px-3 py-2 lg:border-b-0 lg:border-r">
+    <div className="stack basis-1/2 overflow-auto border-b border-slate-500 px-3 py-2 lg:border-b-0 lg:border-r">
       <Heading className="self-start">Visualization Attributes</Heading>
       {spec ? (
         <table className="table-fixed border-collapse font-mono">
+          <colgroup>
+            <col className="w-32" />
+            <col />
+          </colgroup>
           <thead>
             <th className="border border-slate-400 bg-slate-600 px-2 py-1 text-left font-normal text-white">
               Property
@@ -41,7 +46,7 @@ const SpecViewer: React.FC<Props> = ({ spec }) => {
           </tbody>
         </table>
       ) : (
-        <p>Waiting for visualization selection...</p>
+        <ElementSelectPrompt />
       )}
     </div>
   );

--- a/packages/extension/src/index.css
+++ b/packages/extension/src/index.css
@@ -2,11 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Code Mirror */
-.cm-editor {
-  @apply h-full;
-}
-
 /* File Input */
 input[type="file"],
 input[type="file"]::-webkit-file-upload-button {

--- a/packages/extension/src/index.css
+++ b/packages/extension/src/index.css
@@ -11,56 +11,28 @@ input[type="file"]::-webkit-file-upload-button {
 @layer utilities {
   /* Block Stack */
   .stack {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
+    @apply flex flex-col justify-start;
   }
 
   .stack > * {
     margin-block: 0;
   }
 
-  .stack-xs > * + * {
-    margin-block-start: 0.5rem;
-  }
-
-  .stack-sm > * + * {
+  .stack > * + * {
     margin-block-start: 1rem;
-  }
-
-  .stack-md > * + * {
-    margin-block-start: 1.5rem;
-  }
-
-  .stack-lg > * + * {
-    margin-block-start: 2rem;
   }
 
   /* Inline Stack */
   .stack-h {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
+    @apply flex justify-start;
   }
 
   .stack-h > * {
     margin-inline: 0;
   }
 
-  .stack-h-xs > * + * {
-    margin-inline-start: 0.5rem;
-  }
-
-  .stack-h-sm > * + * {
-    margin-inline-start: 1rem;
-  }
-
-  .stack-h-md > * + * {
-    margin-inline-start: 1.5rem;
-  }
-
-  .stack-h-lg > * + * {
-    margin-inline-start: 2rem;
+  .stack-h > * + * {
+    margin-inline-start: 0.25rem;
   }
 }
 
@@ -92,5 +64,40 @@ input[type="file"]::-webkit-file-upload-button {
 
   .data-grid tr:first-child td {
     @apply border-t-0;
+  }
+
+  .tooltip-content {
+    @apply select-none;
+    animation-duration: 400ms;
+    animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+    will-change: transform, opacity;
+  }
+
+  .tooltip-content[data-state="delayed-open"][data-side="left"] {
+    animation-name: slideRightAndFade;
+  }
+
+  .tooltip-content[data-state="delayed-open"][data-side="bottom"] {
+    animation-name: slideUpAndFade;
+  }
+
+  @keyframes slideRightAndFade {
+    from {
+      @apply -translate-x-0.5 opacity-0;
+    }
+
+    to {
+      @apply translate-x-0 opacity-100;
+    }
+  }
+
+  @keyframes slideUpAndFade {
+    from {
+      @apply translate-y-0.5 opacity-0;
+    }
+
+    to {
+      @apply translate-y-0 opacity-100;
+    }
   }
 }

--- a/packages/extension/src/utils/formatters.tsx
+++ b/packages/extension/src/utils/formatters.tsx
@@ -22,13 +22,13 @@ export function formatOneOrMoreValues(
 ): React.ReactNode {
   if (Array.isArray(values) && values.length > 1) {
     return (
-      <div className="flex items-center overflow-auto">
-        <span>[</span>
+      <div className="stack-h flex-wrap items-center">
+        {'['}
         {intersperse(
           values.map((value) => formatValue(property, value)),
           ', '
         )}
-        <span>]</span>
+        {']'}
       </div>
     );
   } else {

--- a/packages/extension/tailwind.config.js
+++ b/packages/extension/tailwind.config.js
@@ -6,6 +6,7 @@ export default {
       colors: {
         primary: '#419af7',
         secondary: '#8638e5',
+        ['editor-fg']: '#d7deea',
       },
     },
   },

--- a/packages/ui/src/components/CodePane.tsx
+++ b/packages/ui/src/components/CodePane.tsx
@@ -7,9 +7,16 @@ interface Props {
   theme: 'dark' | 'light';
   name: string;
   preClassName?: string;
+  style?: React.CSSProperties;
 }
 
-const CodePane: React.FC<Props> = ({ code, theme, name, preClassName }) => {
+const CodePane: React.FC<Props> = ({
+  code,
+  theme,
+  name,
+  preClassName,
+  style: styleOverride,
+}) => {
   return (
     <Highlight
       code={code}
@@ -23,7 +30,10 @@ const CodePane: React.FC<Props> = ({ code, theme, name, preClassName }) => {
         getLineProps,
         getTokenProps,
       }): React.ReactElement => (
-        <pre className={cs(preClassName, className)} style={style}>
+        <pre
+          className={cs(preClassName, className)}
+          style={{ ...style, ...styleOverride }}
+        >
           {tokens.map((line, lineIdx) => (
             <div
               {...getLineProps({ line, key: `${name}-row-${lineIdx}` })}

--- a/yarn.lock
+++ b/yarn.lock
@@ -737,6 +737,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "@floating-ui/core@npm:1.4.1"
+  dependencies:
+    "@floating-ui/utils": ^0.1.1
+  checksum: be4ab864fe17eeba5e205bd554c264b9a4895a57c573661bbf638357fa3108677fed7ba3269ec15b4da90e29274c9b626d5a15414e8d1fe691e210d02a03695c
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.3.0":
+  version: 1.5.1
+  resolution: "@floating-ui/dom@npm:1.5.1"
+  dependencies:
+    "@floating-ui/core": ^1.4.1
+    "@floating-ui/utils": ^0.1.1
+  checksum: ddb509030978536ba7b321cf8c764ae9d0142a3b1fefb7e6bc050a5de7e825e12131fa5089009edabf7c125fb274886da211a5220fe17a71d875a7a96eb1386c
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react-dom@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "@floating-ui/react-dom@npm:2.0.1"
+  dependencies:
+    "@floating-ui/dom": ^1.3.0
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 00fef2cf69ac2b15952e47505fd9e23f6cc5c20a26adc707862932826d1682f3c30f83c9887abfc93574fdca2d34dd2fc00271527318b1db403549cd6bc9eb00
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@floating-ui/utils@npm:0.1.1"
+  checksum: 548acdda7902f45b0afbe34e2e7f4cbff0696b95bad8c039f80936519de24ef2ec20e79902825b7815294b37f51a7c52ee86288b0688869a57cc229a164d86b4
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.10":
   version: 0.11.10
   resolution: "@humanwhocodes/config-array@npm:0.11.10"
@@ -1612,6 +1650,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-arrow@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@radix-ui/react-arrow@npm:1.0.3"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-primitive": 1.0.3
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 8cca086f0dbb33360e3c0142adf72f99fc96352d7086d6c2356dbb2ea5944cfb720a87d526fc48087741c602cd8162ca02b0af5e6fdf5f56d20fddb44db8b4c3
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-collection@npm:1.0.3":
   version: 1.0.3
   resolution: "@radix-ui/react-collection@npm:1.0.3"
@@ -1680,6 +1738,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-dismissable-layer@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@radix-ui/react-dismissable-layer@npm:1.0.4"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.1
+    "@radix-ui/react-compose-refs": 1.0.1
+    "@radix-ui/react-primitive": 1.0.3
+    "@radix-ui/react-use-callback-ref": 1.0.1
+    "@radix-ui/react-use-escape-keydown": 1.0.3
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: ea86004ed56a10609dd84eef39dc1e57b400d687a35be41bb4aaa06dc7ad6dbd0a8da281e08c8c077fdbd523122e4d860cb7438a60c664f024f77c8b41299ec6
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-id@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-id@npm:1.0.1"
@@ -1693,6 +1775,55 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 446a453d799cc790dd2a1583ff8328da88271bff64530b5a17c102fa7fb35eece3cf8985359d416f65e330cd81aa7b8fe984ea125fc4f4eaf4b3801d698e49fe
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-popper@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-popper@npm:1.1.2"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@floating-ui/react-dom": ^2.0.0
+    "@radix-ui/react-arrow": 1.0.3
+    "@radix-ui/react-compose-refs": 1.0.1
+    "@radix-ui/react-context": 1.0.1
+    "@radix-ui/react-primitive": 1.0.3
+    "@radix-ui/react-use-callback-ref": 1.0.1
+    "@radix-ui/react-use-layout-effect": 1.0.1
+    "@radix-ui/react-use-rect": 1.0.1
+    "@radix-ui/react-use-size": 1.0.1
+    "@radix-ui/rect": 1.0.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 4929daa0d1cccada3cff50de0e00c0d186ffea97a5f28545c77fa85ff9bc5c105a54dddac400c2e2dcac631f0f7ea88e59f2e5ad0f80bb2cb7b62cc7cd30400f
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-portal@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@radix-ui/react-portal@npm:1.0.3"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-primitive": 1.0.3
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: d352bcd6ad65eb43c9e0d72d0755c2aae85e03fb287770866262be3a2d5302b2885aee3cd99f2bbf62ecd14fcb1460703f1dcdc40351f77ad887b931c6f0012a
   languageName: node
   linkType: hard
 
@@ -1808,6 +1939,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-tooltip@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "@radix-ui/react-tooltip@npm:1.0.6"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.1
+    "@radix-ui/react-compose-refs": 1.0.1
+    "@radix-ui/react-context": 1.0.1
+    "@radix-ui/react-dismissable-layer": 1.0.4
+    "@radix-ui/react-id": 1.0.1
+    "@radix-ui/react-popper": 1.1.2
+    "@radix-ui/react-portal": 1.0.3
+    "@radix-ui/react-presence": 1.0.1
+    "@radix-ui/react-primitive": 1.0.3
+    "@radix-ui/react-slot": 1.0.2
+    "@radix-ui/react-use-controllable-state": 1.0.1
+    "@radix-ui/react-visually-hidden": 1.0.3
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 8220f103432e9ad9ff8a828ca890e14bf3323864a0bb145d1ef689cf446ab5ca0af18e5fed5da89db957065c504e79ec12fbe5e551d6e7b84b470fbd672c918d
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-callback-ref@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-use-callback-ref@npm:1.0.1"
@@ -1839,6 +2001,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-use-escape-keydown@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@radix-ui/react-use-escape-keydown@npm:1.0.3"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-use-callback-ref": 1.0.1
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: c6ed0d9ce780f67f924980eb305af1f6cce2a8acbaf043a58abe0aa3cc551d9aa76ccee14531df89bbee302ead7ecc7fce330886f82d4672c5eda52f357ef9b8
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-layout-effect@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-use-layout-effect@npm:1.0.1"
@@ -1851,6 +2029,67 @@ __metadata:
     "@types/react":
       optional: true
   checksum: bed9c7e8de243a5ec3b93bb6a5860950b0dba359b6680c84d57c7a655e123dec9b5891c5dfe81ab970652e7779fe2ad102a23177c7896dde95f7340817d47ae5
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-rect@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@radix-ui/react-use-rect@npm:1.0.1"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/rect": 1.0.1
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 433f07e61e04eb222349825bb05f3591fca131313a1d03709565d6226d8660bd1d0423635553f95ee4fcc25c8f2050972d848808d753c388e2a9ae191ebf17f3
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-size@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@radix-ui/react-use-size@npm:1.0.1"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-use-layout-effect": 1.0.1
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 6cc150ad1e9fa85019c225c5a5d50a0af6cdc4653dad0c21b4b40cd2121f36ee076db326c43e6bc91a69766ccff5a84e917d27970176b592577deea3c85a3e26
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-visually-hidden@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@radix-ui/react-visually-hidden@npm:1.0.3"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-primitive": 1.0.3
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 2e9d0c8253f97e7d6ffb2e52a5cfd40ba719f813b39c3e2e42c496d54408abd09ef66b5aec4af9b8ab0553215e32452a5d0934597a49c51dd90dc39181ed0d57
+  languageName: node
+  linkType: hard
+
+"@radix-ui/rect@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@radix-ui/rect@npm:1.0.1"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+  checksum: aeec13b234a946052512d05239067d2d63422f9ec70bf2fe7acfd6b9196693fc33fbaf43c2667c167f777d90a095c6604eb487e0bce79e230b6df0f6cacd6a55
   languageName: node
   linkType: hard
 
@@ -1910,6 +2149,7 @@ __metadata:
     "@codemirror/lang-javascript": ^6.1.9
     "@observablehq/plot": ^0.6.9
     "@radix-ui/react-tabs": ^1.0.4
+    "@radix-ui/react-tooltip": ^1.0.6
     "@reviz/compiler": ^0.5.0
     "@reviz/ui": ^0.5.0
     "@tanstack/react-table": ^8.9.3


### PR DESCRIPTION
This PR adds custom theming for our CodeMirror editor, inspired by [Night Owl](https://github.com/sdras/night-owl-vscode-theme).

<img width="1552" alt="A screenshot of the themed CodeMirror editor in the reviz extension." src="https://github.com/parkerziegler/reviz/assets/19421190/4d43a3ff-9ffd-4959-bd2e-44b38fedf61b">

This is just to make the interface feel more consistent across the Analyze and Visualize tabs. It also paves the way for us to implement dark / light mode switching and match that to users' preferences.

In addition to theming, there are a _ton_ of small polish updates packed into this PR, including:

- Custom icons to enable / disable the SVG inspector and prompt file uploads
- Altering the display of the prompt to select an SVG element
- Changing the appearance and behavior of the button to run the generated program
- Handling display of specs with _lots_ of unique values (e.g. visualizations with continuous color scales, Bubble Charts with highly varied `r` values)

and more!